### PR TITLE
Added docker-compose, Dockerfile, and crontab

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,27 @@
+FROM debian:latest
+RUN apt-get update && apt-get install -y \ 
+    git \
+    wget \
+    cron \
+    python3 \
+    curl \
+    lsof \
+    python3-pip \
+    procps \
+    systemctl \
+    vim \
+    rsyslog\
+    build-essential \
+    base-files \
+    sudo \
+    nano 
+RUN ln -s /usr/bin/python3 /usr/bin/python
+RUN touch /var/log/cron.log
+RUN systemctl enable rsyslog 
+RUN systemctl start rsyslog
+RUN mkdir /root/stemnet
+WORKDIR /root/stemnet
+ADD crontab.txt crontab.txt
+RUN crontab -u root crontab.txt
+RUN git clone https://github.com/Corey4005/STEMNET-Daily-Files.git 
+CMD ["cron", "-f"]

--- a/crontab.txt
+++ b/crontab.txt
@@ -1,2 +1,2 @@
-# test 1
-* * * * * (cd /root/stemnet/STEMNET-Daily-Files/ && python main.py) >> /root/stemnet/output.log 2>&1
+# Run Hourly
+0 * * * * (cd /root/stemnet/STEMNET-Daily-Files/ && python main.py) >> /root/stemnet/output.log 2>&1

--- a/crontab.txt
+++ b/crontab.txt
@@ -1,0 +1,2 @@
+# test 1
+* * * * * (cd /root/stemnet/STEMNET-Daily-Files/ && python main.py) >> /root/stemnet/output.log 2>&1

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+---
+services:
+  stemnet:
+    container_name: stemnet
+    build: .
+    tty: true
+    environment:
+      - TZ=America/Chicago
+


### PR DESCRIPTION
To run this in docker, either run `docker compose up -d` or `docker-compose up -d` and get a cup of coffee.

Getting an error below.  Here's the info you should know about before putting this into the "live" repo.  

[me@myserver stemnet]$ docker exec -it stemnet bash
root@71f711983cde:~/stemnet# python -V
Python 3.11.2

I changed the cron entry to output to output.log file. This Debian 12 build shows the error below.   It's possible I can work around this by installing Python 3.9, _if_ it's available in the repos.



fetching SN003017
         success

fetching SN003018
         success

fetching SN003021
         success

fetching SN003026
         success

fetching SN004001
         success

All possible data downloaded.
Traceback (most recent call last):
  File "/root/stemnet/STEMNET-Daily-Files/./process_daily.py", line 157, in <module>
    clean_timestamps = [try_epoch_to_date(record, station, bad_epoch_dictionary) for record in records_to_create]
                                                                                               ^^^^^^^^^^^^^^^^^
NameError: name 'records_to_create' is not defined